### PR TITLE
Expand team page with all contributors from training materials and reference documents

### DIFF
--- a/content/pages/about-team.adoc
+++ b/content/pages/about-team.adoc
@@ -12,7 +12,7 @@ AP 210 is developed and maintained under *ISO Technical Committee 184, Subcommit
 
 == Key Contributors
 
-The following individuals have made significant contributions to AP 210 development and its supporting research:
+The following individuals have made significant contributions to AP 210 development, research, and its supporting ecosystem.
 
 === Thomas Thurman — AP 210 Project Leader
 
@@ -41,11 +41,140 @@ The following individuals have made significant contributions to AP 210 developm
 * Coordinated AP 210 development across PDES Inc., NIST, Boeing, Rockwell Collins, and the ISO TC 184/SC 4 community
 * Chaired the AP 210 design rule formalism discussions with Gregory Smith (Boeing) and Manas Bajaj (Georgia Tech)
 
-=== Other Key Contributors
+*Selected publications:* Co-author of <<ref-nist-ams-100-51>>, <<ref-nist-gcr-15-990>>, <<ref-plm-denno>>, <<ref-incose-denno>>, and <<ref-nistir-7717>>.
 
-* *Allison Barnard Feeney* — NIST research leadership and standards methodology
-* *Michael Keenan* — NIST research engineering and implementation
-* *Kevin Brady* — NIST strategic direction for STEP standards
+=== Allison Barnard Feeney — NIST Research Leader
+
+*Allison Barnard Feeney* is a *Computer Scientist at NIST* who provided research leadership and standards methodology for AP 210 and the broader STEP program.
+
+*Standards research:*
+
+* Led NIST research on product manufacturing information (PMI) representation in STEP standards
+* Co-authored <<ref-nist-ams-100-51>> on migrating ISO 10303 PMI models to a common core
+* Advanced standards methodology for interoperability of product data across the STEP application protocol family
+
+*Standards development:*
+
+* Contributed to the development and validation of multiple STEP application protocols
+* Participated in ISO TC 184/SC 4 standards development activities
+* Guided NIST research partnerships with PDES Inc. and industry
+
+=== Kevin Brady — NIST Strategic Direction
+
+*Kevin Brady* provided *strategic direction for STEP standards* at NIST, guiding the long-term vision for industrial data interoperability.
+
+*Research leadership:*
+
+* Co-authored <<ref-nistir-7677>> (AP210 Edition 2 Concept of Operations) with Jamie Stori, defining the operational framework for the standard
+* Co-authored <<ref-nist-gcr-15-990>> on the representation of thermal resistor network models for packaged components in STEP AP210 Edition 2
+* Directed NIST programs supporting STEP implementation and validation across industry
+
+*Strategic impact:*
+
+* Shaped NIST strategy for standards-based engineering data exchange
+* Fostered collaboration between NIST, PDES Inc., and defense industry partners
+
+=== Michael Keenan — NIST Research Engineering
+
+*Michael Keenan* contributed *research engineering and implementation* for AP 210 at NIST.
+
+*Implementation work:*
+
+* Developed the NIST JSDAI reference implementation for AP210, including the MIMqueries interface and model traversal APIs
+* Built validation tools and test infrastructure used to verify AP210 conformance
+* Contributed to test case development for the PDES Test Cases Project
+
+*Engineering contributions:*
+
+* Supported the integration of AP210 data with design and analysis tools
+* Participated in interoperability testing across multiple vendor implementations
+
+=== Peter Denno — NIST Systems Engineering and Information Modeling
+
+*Peter Denno* is a *Computer Scientist at NIST* specializing in systems engineering, information modeling, and integration schema.
+
+*Research contributions:*
+
+* Co-authored <<ref-plm-denno>> on requirements for information technology supporting product lifecycle management, analyzing cohesion and traceability in engineering data
+* Co-authored <<ref-incose-denno>> on enabling model-based systems engineering disciplines, connecting AP210 with MBSE methodology
+* Developed process-aware integration schema concepts that advanced the theoretical foundation for AP210 as an integration standard
+
+*Standards and tools:*
+
+* Contributed to the EXPRESS-X mapping language development (ISO 10303-14)
+* Advanced AP233 (systems engineering) and SysML integration with STEP data
+* Developed model-driven integration techniques for existing engineering models
+
+=== Jamie Stori — Concept of Operations
+
+*Jamie Stori* of *SFM Technology, Inc.* defined the conceptual framework for AP210 Edition 2.
+
+*Standards development:*
+
+* Authored <<ref-nistir-7677>> (AP210 Edition 2 Concept of Operations), the foundational document describing how AP210 addresses electronic assembly design data exchange
+* Co-authored <<ref-nist-gcr-15-990>> on the representation of thermal resistor network models for packaged components in STEP AP210
+
+*Analytical work:*
+
+* Developed thermal management models for electronic components using STEP AP210 data structures
+* Contributed to the analysis of how AP210 could represent thermal and physical characteristics of packaged electronic components
+
+=== John Mettenburg — Rockwell Collins Systems Engineering
+
+*John Mettenburg* is a *Principal Systems Engineer at Rockwell Collins* (now Collins Aerospace) who contributed to model-based systems engineering for AP210.
+
+*Research contributions:*
+
+* Co-authored <<ref-incose-denno>> on enabling model-based systems engineering disciplines, demonstrating how AP210 data supports systems engineering workflows
+* Advanced the application of AP210 in the context of defense and aerospace systems engineering
+
+*Industry application:*
+
+* Bridged AP210 data standards with model-based systems engineering practices at Rockwell Collins
+* Contributed to the practical validation of AP210 concepts in real-world engineering environments
+
+=== Dwayne Hardy — American Systems
+
+*Dwayne Hardy* of *American Systems* contributed to the systems engineering research that connected AP210 with broader MBSE methodology.
+
+*Research contributions:*
+
+* Co-authored <<ref-incose-denno>> on enabling model-based systems engineering disciplines
+* Contributed to the analysis of how STEP standards, including AP210, support systems engineering data integration
+
+== Additional Contributors
+
+The following individuals contributed to AP 210 through test case development, training materials, implementation work, and standards discussions within the PDES and NIST programs:
+
+* *James F. Adams* (The Boeing Company) — author of PDES test cases including PDES-181 (Complex Multi-layer PCA)
+* *Steve Waterbury* (NASA) — test case author and contributor to product lifecycle management research at NIST
+* *Mike Benda* — co-contributor on recommended practices for AP210
+* *Jim Evans* — PDES test case author
+* *Kevin Cline* — PDES test case author
+* *Craig Lanning* — PDES test case author
+* *Paul Monson* — PDES test case author
+
+== Reference Publications
+
+[[ref-nist-ams-100-51]] . *NIST AMS 100-51:* _On Migrating ISO 10303 PMI Models to a Common Core_ — Allison Barnard Feeney and Thomas Thurman. https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=935394[Available from NIST^].
+
+[[ref-nist-ams-300-12]] . *NIST AMS 300-12:* _Research Results and Recommendations for Universally Unique Identifiers_ — NIST. https://nvlpubs.nist.gov/nistpubs/ams/NIST.AMS.300-12.pdf[Available from NIST^].
+
+[[ref-nist-gcr-15-990]] . *NIST GCR 15-990:* _Representation of Thermal Resistor Network Model for Packaged Component in STEP AP210 Edition 2_ — Jamie Stori, Kevin Brady, and Thomas Thurman. https://www.nist.gov/publications/representation-thermal-resistor-network-model-packaged-component-step-ap210-edition-2[Available from NIST^].
+
+[[ref-nist-gcr-15-991]] . *NIST GCR 15-991:* _Extensions of Recommended Practices for GD&T in STEP-AP210 in the Context of Packaged Electronic Components_ — NIST. https://www.nist.gov/publications/extensions-recommended-practices-gdt-step-ap210-context-packaged-electronic-components[Available from NIST^].
+
+[[ref-nistir-6991]] . *NIST IR 6991:* _Representation of Thermal Resistor Network Model for a Packaged Component for Use in STEP AP210_ — NIST. https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=903903[Available from NIST^].
+
+[[ref-nistir-7648]] . *NIST IR 7648:* _NISTIR 7648_ — NIST. https://doi.org/10.6028/NIST.IR.7648[Available from NIST^].
+
+[[ref-plm-denno]] . _Requirements on Information Technology for Product Lifecycle Management_ — Peter Denno (NIST) and Thomas Thurman (Rockwell Collins). https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=822191[Available from NIST^].
+
+[[ref-incose-denno]] . _On Enabling a Model-Based Systems Engineering Discipline_ — Peter Denno (NIST), Thomas Thurman (Rockwell Collins), John Mettenburg (Rockwell Collins), and Dwayne Hardy (American Systems). https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=824653[Available from NIST^].
+
+[[ref-nistir-7677]] . *NIST IR 7677:* _AP210 Edition 2 Concept of Operations_ — Jamie Stori (SFM Technology) and Kevin Brady (NIST). https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=905123[Available from NIST^].
+
+[[ref-nistir-7717]] . *NIST IR 7717:* _Use Cases for the Management and Maintenance of Multi-Domain AP 210 Component Models_ — NIST. https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=906355[Available from NIST^].
 
 == NIST
 


### PR DESCRIPTION
Comprehensively identifies and documents all contributors to AP 210 from the training materials and reference PDFs in `reference-docs/`.

Changes:
- Restructures Key Contributors so all 8 people get equal `===` subsections (Thomas Thurman listed first as Project Leader)
- Adds 5 new key contributors: Peter Denno (NIST), Jamie Stori (SFM Technology), John Mettenburg (Rockwell Collins), Dwayne Hardy (American Systems), and expands existing entries for Feeney, Brady, Keenan
- Adds Additional Contributors section with 7 test case authors (Adams, Waterbury, Benda, Evans, Cline, Lanning, Monson)
- Adds Reference Publications section citing 10 NIST documents with online URLs
- Each contributor entry cross-references their cited publications

134 lines added, 5 lines removed from `content/pages/about-team.adoc`.