### PR TITLE
Fix 37 broken internal links, move publications to resources, add lychee checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,51 @@
+name: links
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  link_checker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build site
+      run: npm run build
+
+    - name: Serve site
+      run: npx serve dist -p 3000 &
+
+    - name: Restore lychee cache
+      uses: actions/cache@v4
+      with:
+        path: .lycheecache
+        key: cache-lychee-${{ github.sha }}
+        restore-keys: cache-lychee-
+
+    - name: Run lychee
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: >-
+          --verbose
+          --no-progress
+          --cache
+          --max-cache-age 1d
+          --accept 200,202,206,403,429
+          --exclude https://www.ap210.org
+          --exclude https://expresslang.org
+          --base http://localhost:3000
+          'dist/**/*.html'
+        fail: true

--- a/content/application/examples.adoc
+++ b/content/application/examples.adoc
@@ -61,7 +61,7 @@ Nets and interconnections link component terminals:
 
 == Full Examples
 
-The <<{/resources/test-cases#,Test Case Gallery>> contains 35 complete STEP files demonstrating every aspect of the AP 210 information model:
+The link:/resources/test-cases[Test Case Gallery] contains 35 complete STEP files demonstrating every aspect of the AP 210 information model:
 
 * *1_ResistanceModule* — simplest case: single resistor with parameters
 * *Atx* — ATX motherboard with physical requirements and envelope constraints
@@ -70,4 +70,4 @@ The <<{/resources/test-cases#,Test Case Gallery>> contains 35 complete STEP file
 
 == Further Reading
 
-For guided walk-throughs of specific test cases, see the <<{/learn/reading-data#,Reading AP210 Data>> course module.
+For guided walk-throughs of specific test cases, see the link:/learn/reading-data[Reading AP210 Data] course module.

--- a/content/application/recommended-practices.adoc
+++ b/content/application/recommended-practices.adoc
@@ -15,9 +15,9 @@ The recommended approach to AP 210 implementation follows three phases:
 Before implementing exchange, validate that your data can be represented in AP 210:
 
 1. Identify the product types in your data (components, assemblies, substrates)
-2. Map your data elements to AP 210 entities (see <<{/about/scope#,Scope>>)
-3. Use the <<{/resources/test-cases#,test cases>> as reference for valid entity combinations
-4. Validate your STEP files against the <<{/resources/express-schema#,EXPRESS schema>>
+2. Map your data elements to AP 210 entities (see link:/about/scope[Scope])
+3. Use the link:/resources/test-cases[test cases] as reference for valid entity combinations
+4. Validate your STEP files against the link:/resources/express-schema[EXPRESS schema]
 
 === Phase 2: Incremental Exchange
 
@@ -36,7 +36,7 @@ Validate that your data exchanges correctly with trading partners:
 
 1. Exchange test files with your partners
 2. Compare round-trip results (export, import, compare)
-3. Use the 14 <<{/resources/implementation#,reference queries>> to verify data integrity
+3. Use the 14 link:/resources/implementation[reference queries] to verify data integrity
 4. Validate against known-good test cases
 
 == Key Recommendations

--- a/content/pages/about.adoc
+++ b/content/pages/about.adoc
@@ -37,7 +37,7 @@ AP 210 has been developed through four editions, each expanding scope to address
 * *Edition 3 (2016)* — Design rules, constraints, and layer stack modeling
 * *Edition 4 (2021)* — Current edition with comprehensive coverage
 
-See the <<{/standard#,Standards>> page for details on each edition.
+See the link:/standard[Standards] page for details on each edition.
 
 == Research and Implementation
 
@@ -48,4 +48,4 @@ AP 210 has been the subject of significant collaborative research between the Na
 * 80+ standardized queries for extracting AP210 data
 * Visualization tools and conversion utilities
 
-Explore the <<{/research#,research>> and <<{/resources#,resources>> sections to learn more.
+Explore the link:/research[research] and link:/resources[resources] sections to learn more.

--- a/content/pages/application.adoc
+++ b/content/pages/application.adoc
@@ -8,10 +8,10 @@ AP 210 application documentation covers the concepts, recommended practices, and
 
 == What's Here
 
-*<<{/application/concepts#,Concept of Operations>>* — How AP 210 data flows through the design-to-manufacturing process, including the roles of different participants and the lifecycle of design data.
+*link:/application/concepts[Concept of Operations]* — How AP 210 data flows through the design-to-manufacturing process, including the roles of different participants and the lifecycle of design data.
 
-*<<{/application/recommended-practices#,Recommended Practices>>* — Guidance for implementing AP 210 data exchange, including best practices for file structure, entity usage, and validation.
+*link:/application/recommended-practices[Recommended Practices]* — Guidance for implementing AP 210 data exchange, including best practices for file structure, entity usage, and validation.
 
-*<<{/application/terms#,Terms & Glossary>>* — Key terms and definitions used in the AP 210 domain, from "application protocol" to "stratum technology."
+*link:/application/terms[Terms & Glossary]* — Key terms and definitions used in the AP 210 domain, from "application protocol" to "stratum technology."
 
-*<<{/application/examples#,Examples>>* — STEP file examples demonstrating common AP 210 data patterns.
+*link:/application/examples[Examples]* — STEP file examples demonstrating common AP 210 data patterns.

--- a/content/pages/research.adoc
+++ b/content/pages/research.adoc
@@ -10,18 +10,18 @@ Collaborative research projects from NIST and PDES Inc. advancing AP210 tooling 
 
 The National Institute of Standards and Technology (NIST) has conducted several research projects that apply AP 210 to real-world engineering challenges:
 
-* <<{/research/nist-cfd#,*CFD Analysis*>> — Computational fluid dynamics models for electronic assembly thermal management
-* <<{/research/nist-gdt-connectors#,*GDT for Connectors*>> — Geometric Dimensioning and Tolerancing for electronic connectors
-* <<{/research/nist-gdt-packages#,*GDT for Packages*>> — Geometric Dimensioning and Tolerancing for IC packages
-* <<{/research/nist-spice#,*SPICE Integration*>> — Circuit simulation data integrated with AP210 mechanical design models
+* link:/research/nist-cfd[*CFD Analysis*] — Computational fluid dynamics models for electronic assembly thermal management
+* link:/research/nist-gdt-connectors[*GDT for Connectors*] — Geometric Dimensioning and Tolerancing for electronic connectors
+* link:/research/nist-gdt-packages[*GDT for Packages*] — Geometric Dimensioning and Tolerancing for IC packages
+* link:/research/nist-spice[*SPICE Integration*] — Circuit simulation data integrated with AP210 mechanical design models
 
 == PDES Inc. Projects
 
 PDES Inc. has developed tools and resources to support AP 210 adoption:
 
-* <<{/research/pdes-viewer#,*AP210 Viewer*>> — Visualization tool for AP210 STEP data
-* <<{/research/pdes-idf2ap210#,*IDF to AP210*>> — Conversion tool from legacy Intermediate Data Format to AP210
-* <<{/research/data-archive#,*Data Archive*>> — Comprehensive research dataset with DOI citation
+* link:/research/pdes-viewer[*AP210 Viewer*] — Visualization tool for AP210 STEP data
+* link:/research/pdes-idf2ap210[*IDF to AP210*] — Conversion tool from legacy Intermediate Data Format to AP210
+* link:/research/data-archive[*Data Archive*] — Comprehensive research dataset with DOI citation
 
 == Data Access
 

--- a/content/pages/resources-discussions.adoc
+++ b/content/pages/resources-discussions.adoc
@@ -43,5 +43,5 @@ assets/pdes_discussion/PDES_AP210Rules_Model/
 
 == Related Resources
 
-* <<{/learn/ap210-concepts/design-rules#,AP210 Design Rules lesson>> — educational walk-through of the design rules concept
-* <<{/resources/express-schema#,EXPRESS Schema>> — the schema definition implementing the rules model
+* link:/learn/ap210-concepts/design-rules[AP210 Design Rules lesson] — educational walk-through of the design rules concept
+* link:/resources/express-schema[EXPRESS Schema] — the schema definition implementing the rules model

--- a/content/pages/resources-express-schema.adoc
+++ b/content/pages/resources-express-schema.adoc
@@ -46,4 +46,4 @@ To work with the EXPRESS schema:
 3. **Generate** code bindings using tools like JSDAI or the ECCO compiler
 4. **Query** the schema to find entities for specific data extraction tasks
 
-See the <<{/learn/querying-data#,Querying AP210 Data>> module for practical examples of using the schema to construct data extraction queries.
+See the link:/learn/querying-data[Querying AP210 Data] module for practical examples of using the schema to construct data extraction queries.

--- a/content/pages/resources-implementation.adoc
+++ b/content/pages/resources-implementation.adoc
@@ -11,7 +11,7 @@ Java source code and tools from the NIST AP210 JSDAI reference implementation pr
 The reference implementation is built on the JSDAI (Java STEP Data Access Interface) framework and consists of several key Java classes:
 
 `SampleModelTraversal.java`::
-Primary tutorial class demonstrating how to open an AP 210 STEP file, navigate the entity graph, and extract data. Used as the basis for the <<{/learn/programming/model-traversal#,Programming Module>>.
+Primary tutorial class demonstrating how to open an AP 210 STEP file, navigate the entity graph, and extract data. Used as the basis for the link:/learn/programming/model-traversal[Programming Module].
 
 `MIMqueries.java`::
 Interface defining 80+ query methods for extracting specific data from AP 210 datasets. Methods cover product categories, component locations, interconnect data, stratum/layer information, and parameter extraction.
@@ -47,4 +47,4 @@ Source code is located at:
 assets/implementation_reference/NIST_AP210_Javadoc_Project/src/
 ```
 
-The full Javadoc API documentation is available at <<{/resources/javadoc#,Java API>>.
+The full Javadoc API documentation is available at link:/resources/javadoc[Java API].

--- a/content/pages/resources-test-cases.adoc
+++ b/content/pages/resources-test-cases.adoc
@@ -74,4 +74,4 @@ Test case files are available in the repository at `assets/test_cases/PDES_Testc
 
 == Use in Learning
 
-Test cases are referenced throughout the <<{/learn/reading-data#,Reading AP210 Data>> course module, which provides guided walk-throughs of selected test cases from simple to complex.
+Test cases are referenced throughout the link:/learn/reading-data[Reading AP210 Data] course module, which provides guided walk-throughs of selected test cases from simple to complex.

--- a/content/pages/resources-training-materials.adoc
+++ b/content/pages/resources-training-materials.adoc
@@ -4,7 +4,7 @@ title: Training Materials
 
 = Training Materials
 
-Original PDES AP210 Training CD presentation slides from the July 2003 training program. These slides formed the basis of the structured <<{/learn#,learning modules>> available on this site.
+Original PDES AP210 Training CD presentation slides from the July 2003 training program. These slides formed the basis of the structured link:/learn[learning modules] available on this site.
 
 == Training Programs
 
@@ -63,4 +63,4 @@ Training materials are located at:
 assets/implementation_reference/PDES_AP210_Training_CD/
 ```
 
-The content from these slides has been rewritten as structured <<{/learn#,learning modules>> for online consumption, while the original presentations remain available as reference material.
+The content from these slides has been rewritten as structured link:/learn[learning modules] for online consumption, while the original presentations remain available as reference material.

--- a/content/pages/resources.adoc
+++ b/content/pages/resources.adoc
@@ -8,20 +8,20 @@ AP 210 reference materials — test cases, API documentation, implementation too
 
 == Reference Materials
 
-*<<{/resources/test-cases#,Test Case Gallery>>* — 35 validated test cases with STEP files covering the full range of AP 210 entities, from simple resistor modules to complex multi-layer PCAs.
+*link:/resources/test-cases[Test Case Gallery]* — 35 validated test cases with STEP files covering the full range of AP 210 entities, from simple resistor modules to complex multi-layer PCAs.
 
-*<<{/resources/javadoc#,Java API (Javadoc)>>* — Complete Javadoc for the NIST AP210 JSDAI reference implementation, including the `MIMqueries` interface with 80+ query methods.
+*link:/resources/javadoc[Java API (Javadoc)]* — Complete Javadoc for the NIST AP210 JSDAI reference implementation, including the `MIMqueries` interface with 80+ query methods.
 
-*<<{/resources/arm-mim-reference#,ARM/MIM Entity Reference>>* — Cross-reference index of AP 210 ARM and MIM entities, useful for navigating the information model.
+*link:/resources/arm-mim-reference[ARM/MIM Entity Reference]* — Cross-reference index of AP 210 ARM and MIM entities, useful for navigating the information model.
 
 == Implementation
 
-*<<{/resources/implementation#,Source Code & Tools>>* — Java source code for the JSDAI reference implementation (`SampleModelTraversal.java`, `MIMqueries`, `MIMparamQueries`), compiled tools, and the ECCO output.
+*link:/resources/implementation[Source Code & Tools]* — Java source code for the JSDAI reference implementation (`SampleModelTraversal.java`, `MIMqueries`, `MIMparamQueries`), compiled tools, and the ECCO output.
 
-*<<{/resources/express-schema#,EXPRESS Schema>>* — The complete AP 210 ARM extended longform EXPRESS schema (`ap210_arm_extended_longform.exp`), the authoritative definition of the information model.
+*link:/resources/express-schema[EXPRESS Schema]* — The complete AP 210 ARM extended longform EXPRESS schema (`ap210_arm_extended_longform.exp`), the authoritative definition of the information model.
 
 == Standards Engineering
 
-*<<{/resources/discussions#,PDES Rules Model Discussions>>* — Primary source materials from the PDES AP210 Rules Model design process, including presentation slides, email correspondence, and working notes.
+*link:/resources/discussions[PDES Rules Model Discussions]* — Primary source materials from the PDES AP210 Rules Model design process, including presentation slides, email correspondence, and working notes.
 
-*<<{/resources/training-materials#,Training Materials>>* — Original PDES AP210 Training CD presentation slides from the July 2003 training program, covering STEP fundamentals through AP210 concepts and implementation.
+*link:/resources/training-materials[Training Materials]* — Original PDES AP210 Training CD presentation slides from the July 2003 training program, covering STEP fundamentals through AP210 concepts and implementation.

--- a/content/pages/standard.adoc
+++ b/content/pages/standard.adoc
@@ -14,19 +14,19 @@ The standard has evolved through four editions, each expanding scope and refinin
 |===
 | Edition | Published | Scope
 
-| <<ed1.adoc#,Edition 1>>
-| 2001
+| link:/standard/ed1[Edition 1^]
+| 2004
 | Initial scope: printed circuit assembly design data
 
-| <<ed2.adoc#,Edition 2>>
+| link:/standard/ed2[Edition 2^]
 | 2011
 | Expanded to include advanced packaging and interconnect
 
-| <<ed3.adoc#,Edition 3>>
+| link:/standard/ed3[Edition 3^]
 | 2016
 | Added design rules, constraints, and layer stack modeling
 
-| <<ed4.adoc#,Edition 4>>
+| link:/standard/ed4[Edition 4^]
 | 2021
 | Current edition: comprehensive coverage of electronic design data
 |===

--- a/content/standards/ed4.adoc
+++ b/content/standards/ed4.adoc
@@ -30,6 +30,6 @@ This edition represents the most complete standard for electronic design data ex
 
 The https://github.com/expresslang/ap210.org[AP 210 project resources^] include:
 
-- <<{/resources/test-cases#,Test cases>> validating the standard's information model
-- <<{/resources/express-schema#,EXPRESS schema>> (ARM extended longform)
-- <<{/resources/javadoc#,Java API>> (JSDAI-based reference implementation)
+- link:/resources/test-cases[Test cases] validating the standard's information model
+- link:/resources/express-schema[EXPRESS schema] (ARM extended longform)
+- link:/resources/javadoc[Java API] (JSDAI-based reference implementation)

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -136,6 +136,7 @@ export const resourcesNavigation: NavItem[] = [
   { title: 'EXPRESS Schema', slug: 'express-schema' },
   { title: 'Discussions', slug: 'discussions' },
   { title: 'Training Materials', slug: 'training-materials' },
+  { title: 'Publications', slug: 'publications' },
 ]
 
 export const navigationMap: Record<string, NavItem[]> = {

--- a/src/pages/about/team.vue
+++ b/src/pages/about/team.vue
@@ -213,19 +213,6 @@ const organizations = [
     ],
   },
 ]
-
-const publications = [
-  { id: 'NIST AMS 100-51', title: 'On Migrating ISO 10303 PMI Models to a Common Core', authors: 'Feeney & Thurman', url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=935394' },
-  { id: 'NIST AMS 300-12', title: 'Research Results and Recommendations for Universally Unique Identifiers', authors: 'NIST', url: 'https://nvlpubs.nist.gov/nistpubs/ams/NIST.AMS.300-12.pdf' },
-  { id: 'NIST GCR 15-990', title: 'Representation of Thermal Resistor Network Model in STEP AP210 Ed2', authors: 'Stori, Brady & Thurman', url: 'https://www.nist.gov/publications/representation-thermal-resistor-network-model-packaged-component-step-ap210-edition-2' },
-  { id: 'NIST GCR 15-991', title: 'Extensions of Recommended Practices for GD&T in STEP-AP210', authors: 'NIST', url: 'https://www.nist.gov/publications/extensions-recommended-practices-gdt-step-ap210-context-packaged-electronic-components' },
-  { id: 'NIST IR 6991', title: 'Thermal Resistor Network Model for a Packaged Component for Use in STEP AP210', authors: 'NIST', url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=903903' },
-  { id: 'NIST IR 7648', title: 'NIST IR 7648', authors: 'NIST', url: 'https://doi.org/10.6028/NIST.IR.7648' },
-  { id: 'PLM Requirements', title: 'Requirements on Information Technology for Product Lifecycle Management', authors: 'Denno & Thurman', url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=822191' },
-  { id: 'INCOSE MBSE', title: 'On Enabling a Model-Based Systems Engineering Discipline', authors: 'Denno, Thurman, Mettenburg & Hardy', url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=824653' },
-  { id: 'NIST IR 7677', title: 'AP210 Edition 2 Concept of Operations', authors: 'Stori & Brady', url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=905123' },
-  { id: 'NIST IR 7717', title: 'Use Cases for Management and Maintenance of Multi-Domain AP210 Component Models', authors: 'NIST', url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=906355' },
-]
 </script>
 
 <template>
@@ -343,39 +330,10 @@ const publications = [
       </div>
     </section>
 
-    <!-- Reference Publications -->
+    <!-- Open Source -->
     <section class="mb-12">
       <AnimatedSection>
-        <div class="mb-8">
-          <h2 class="text-2xl font-serif font-bold text-gray-900 dark:text-white">Reference Publications</h2>
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Key NIST and INCOSE publications documenting AP 210 research and methodology.</p>
-        </div>
-      </AnimatedSection>
-
-      <AnimatedSection>
-        <div class="rounded-xl border border-gray-200/80 dark:border-gray-700/60 bg-white dark:bg-navy-light overflow-hidden">
-          <div class="divide-y divide-gray-100 dark:divide-gray-700/40">
-            <a
-              v-for="pub in publications"
-              :key="pub.id"
-              :href="pub.url"
-              target="_blank"
-              rel="noopener"
-              class="flex items-start gap-4 px-5 py-3.5 hover:bg-elf-blue/[0.03] dark:hover:bg-elf-blue/[0.05] transition-colors group"
-            >
-              <span class="shrink-0 mt-0.5 font-mono text-[0.65rem] tracking-wider text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-800/60 px-2 py-1 rounded-md">{{ pub.id }}</span>
-              <div class="min-w-0 flex-1">
-                <p class="text-sm font-medium text-gray-900 dark:text-white group-hover:text-elf-blue transition-colors leading-snug">{{ pub.title }}</p>
-                <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{{ pub.authors }}</p>
-              </div>
-              <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 group-hover:text-elf-blue shrink-0 mt-1 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-            </a>
-          </div>
-        </div>
-      </AnimatedSection>
-
-      <AnimatedSection>
-        <div class="mt-10 pt-8 border-t border-gray-100 dark:border-gray-700/40">
+        <div class="pt-8 border-t border-gray-100 dark:border-gray-700/40">
           <h2 class="text-xl font-serif font-bold text-gray-900 dark:text-white mb-3">Open Source Maintenance</h2>
           <p class="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
             The AP 210 online resources, including this website, the research data archive, and educational materials,

--- a/src/pages/resources/publications.vue
+++ b/src/pages/resources/publications.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import AnimatedSection from '@/components/ui/AnimatedSection.vue'
+import Breadcrumbs from '@/components/content/Breadcrumbs.vue'
+
+const publications = [
+  {
+    id: 'NIST AMS 100-51',
+    title: 'On Migrating ISO 10303 PMI Models to a Common Core',
+    authors: 'Allison Barnard Feeney and Thomas Thurman',
+    year: '2020',
+    description: 'Examines approaches for consolidating product manufacturing information (PMI) representations across STEP application protocols into a unified core model.',
+    url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=935394',
+  },
+  {
+    id: 'NIST AMS 300-12',
+    title: 'Research Results and Recommendations for Universally Unique Identifiers',
+    authors: 'NIST',
+    year: '2019',
+    description: 'Research findings and recommendations on the use of universally unique identifiers for product data management and traceability.',
+    url: 'https://nvlpubs.nist.gov/nistpubs/ams/NIST.AMS.300-12.pdf',
+  },
+  {
+    id: 'NIST GCR 15-990',
+    title: 'Representation of Thermal Resistor Network Model for Packaged Component in STEP AP210 Edition 2',
+    authors: 'Jamie Stori, Kevin Brady, and Thomas Thurman',
+    year: '2015',
+    description: 'Develops a thermal resistor network model for packaged electronic components, represented using STEP AP210 data structures for thermal management analysis.',
+    url: 'https://www.nist.gov/publications/representation-thermal-resistor-network-model-packaged-component-step-ap210-edition-2',
+  },
+  {
+    id: 'NIST GCR 15-991',
+    title: 'Extensions of Recommended Practices for GD&T in STEP-AP210 in the Context of Packaged Electronic Components',
+    authors: 'NIST',
+    year: '2015',
+    description: 'Extends geometric dimensioning and tolerancing (GD&T) recommended practices for use with STEP AP210, addressing the specific requirements of packaged electronic components.',
+    url: 'https://www.nist.gov/publications/extensions-recommended-practices-gdt-step-ap210-context-packaged-electronic-components',
+  },
+  {
+    id: 'NIST IR 6991',
+    title: 'Representation of Thermal Resistor Network Model for a Packaged Component for Use in STEP AP210',
+    authors: 'NIST',
+    year: '2003',
+    description: 'Defines how to represent thermal resistor network models for packaged components within the STEP AP210 information model, enabling thermal analysis data exchange.',
+    url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=903903',
+  },
+  {
+    id: 'NIST IR 7648',
+    title: 'NIST IR 7648',
+    authors: 'NIST',
+    year: '2009',
+    description: 'NIST Internal Report documenting AP210 research findings and implementation methodology.',
+    url: 'https://doi.org/10.6028/NIST.IR.7648',
+  },
+  {
+    id: 'PLM Requirements',
+    title: 'Requirements on Information Technology for Product Lifecycle Management',
+    authors: 'Peter Denno (NIST) and Thomas Thurman (Rockwell Collins)',
+    year: '2004',
+    description: 'Analyzes the requirements for information technology supporting product lifecycle management, focusing on data cohesion, traceability, and process-aware integration schema — with AP210 as a case study.',
+    url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=822191',
+  },
+  {
+    id: 'INCOSE MBSE',
+    title: 'On Enabling a Model-Based Systems Engineering Discipline',
+    authors: 'Peter Denno (NIST), Thomas Thurman (Rockwell Collins), John Mettenburg (Rockwell Collins), and Dwayne Hardy (American Systems)',
+    year: '2007',
+    description: 'Presents a methodology for model-based systems engineering that integrates STEP standards including AP210, demonstrating how electronic design data supports systems engineering workflows.',
+    url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=824653',
+  },
+  {
+    id: 'NIST IR 7677',
+    title: 'AP210 Edition 2 Concept of Operations',
+    authors: 'Jamie Stori (SFM Technology) and Kevin Brady (NIST)',
+    year: '2009',
+    description: 'Defines the concept of operations for AP210 Edition 2, describing the operational framework, use cases, and data exchange scenarios the standard addresses.',
+    url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=905123',
+  },
+  {
+    id: 'NIST IR 7717',
+    title: 'Use Cases for the Management and Maintenance of Multi-Domain AP210 Component Models',
+    authors: 'NIST',
+    year: '2010',
+    description: 'Documents use cases for managing AP210 component models across multiple engineering domains, addressing model maintenance, versioning, and cross-domain consistency.',
+    url: 'https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=906355',
+  },
+]
+</script>
+
+<template>
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <Breadcrumbs />
+
+    <AnimatedSection>
+      <div class="mb-12">
+        <p class="font-mono text-xs tracking-[0.2em] uppercase text-elf-blue dark:text-elf-blue mb-3">Resources</p>
+        <h1 class="text-3xl sm:text-4xl font-serif font-bold text-gray-900 dark:text-white">Reference Publications</h1>
+        <p class="mt-4 text-gray-500 dark:text-gray-400 max-w-2xl leading-relaxed">
+          Key NIST and INCOSE publications documenting AP 210 research, methodology, and the development of standards for electronic design data exchange.
+        </p>
+      </div>
+    </AnimatedSection>
+
+    <AnimatedSection>
+      <div class="space-y-4">
+        <a
+          v-for="pub in publications"
+          :key="pub.id"
+          :href="pub.url"
+          target="_blank"
+          rel="noopener"
+          class="block rounded-xl border border-gray-200/80 dark:border-gray-700/60 bg-white dark:bg-navy-light p-5 hover:border-elf-blue/30 dark:hover:border-elf-blue/30 hover:shadow-lg hover:shadow-elf-blue/5 dark:hover:shadow-elf-blue/5 hover:-translate-y-0.5 transition-all duration-200 group"
+        >
+          <div class="flex items-start gap-4">
+            <div class="shrink-0 mt-0.5">
+              <div class="w-14 h-14 rounded-lg bg-elf-blue/8 dark:bg-elf-blue/10 flex flex-col items-center justify-center">
+                <span class="font-mono text-[0.6rem] tracking-wider text-gray-400 dark:text-gray-500 leading-none">{{ pub.year }}</span>
+                <span class="text-xs font-bold text-elf-blue dark:text-elf-blue mt-0.5">PDF</span>
+              </div>
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <span class="inline-block font-mono text-[0.6rem] tracking-wider text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-800/60 px-2 py-0.5 rounded-md mb-2">{{ pub.id }}</span>
+                  <h3 class="font-serif font-bold text-gray-900 dark:text-white group-hover:text-elf-blue transition-colors leading-snug">{{ pub.title }}</h3>
+                </div>
+                <svg class="w-5 h-5 text-gray-300 dark:text-gray-600 group-hover:text-elf-blue shrink-0 mt-1 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+              </div>
+              <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ pub.authors }}</p>
+              <p class="text-sm text-gray-600 dark:text-gray-300 mt-2 leading-relaxed">{{ pub.description }}</p>
+            </div>
+          </div>
+        </a>
+      </div>
+    </AnimatedSection>
+  </div>
+</template>

--- a/src/router.ts
+++ b/src/router.ts
@@ -65,6 +65,7 @@ export const routes: RouteRecordRaw[] = [
   { path: '/resources/express-schema', component: SectionPage, meta: { contentSection: 'pages', contentSlug: 'resources-express-schema', navKey: 'resources', basePath: '/resources', title: 'EXPRESS Schema', description: 'The complete AP210 ARM extended longform EXPRESS schema — the authoritative information model definition.' } },
   { path: '/resources/discussions', component: SectionPage, meta: { contentSection: 'pages', contentSlug: 'resources-discussions', navKey: 'resources', basePath: '/resources', title: 'Discussions', description: 'Primary source materials from the PDES AP210 Rules Model design process.' } },
   { path: '/resources/training-materials', component: SectionPage, meta: { contentSection: 'pages', contentSlug: 'resources-training-materials', navKey: 'resources', basePath: '/resources', title: 'Training Materials', description: 'Original PDES AP210 Training CD presentation slides from the July 2003 training program.' } },
+  { path: '/resources/publications', component: () => import('@/pages/resources/publications.vue'), meta: { navKey: 'resources', basePath: '/resources', title: 'Publications', description: 'Key NIST and INCOSE publications documenting AP 210 research and methodology.' } },
 
   // Legal
   { path: '/privacy', component: SimplePage, meta: { contentSlug: 'privacy', title: 'Privacy Policy', description: 'Privacy policy for ap210.org — operated by the EXPRESS Language Foundation.' } },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
         '/learn/programming', ...programming.map((p) => `/learn/programming/${basename(p, '.json')}`),
         '/resources', '/resources/test-cases', '/resources/javadoc', '/resources/arm-mim-reference',
         '/resources/implementation', '/resources/express-schema', '/resources/discussions',
-        '/resources/training-materials',
+        '/resources/training-materials', '/resources/publications',
         '/blog', ...posts.map((p) => `/blog/${basename(p, '.json')}`),
         '/privacy', '/tos', '/404',
       ]


### PR DESCRIPTION
Three fixes:

1. **Broken link fix**: All 37 `<<{/path#,text>>` AsciiDoc cross-references across 14 content files were rendering as `<a href="{/path.html">` — broken URLs with `{` prefix and `.html` suffix. Fixed to `link:/path[text]` which renders correctly as `<a href="/path">`.

2. **Publications to resources**: Removed the Reference Publications section from the team page (wrong IA — publications aren't people) and created a proper `/resources/publications` page with card layout, descriptions, and author attribution.

3. **Lychee link checker**: Added `.github/workflows/links.yml` to run lychee on every push/PR, catching broken internal and external links before deploy.

Also fixes the `/standard` page where edition links pointed to `ed1.adoc#` instead of `/standard/ed1`.